### PR TITLE
[Chore/#7] LLM API 모델 ChatGpt 추가(기존 Gemini에서 변경)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -3,8 +3,15 @@ from functools import lru_cache
 from typing import Optional
 
 class Settings(BaseSettings):
-    # --- AI / Gemini ---
-    GOOGLE_API_KEY: str
+    # --- LLM Provider ---
+    # "openai" | "gemini" 중 하나. .env에서만 변경한다.
+    LLM_PROVIDER: str = "openai"
+    # None이면 provider 기본값 사용 (openai: gpt-4o / gpt-4o-mini, gemini: gemini-2.5-pro / gemini-2.0-flash)
+    ORCHESTRATOR_MODEL: Optional[str] = None
+    PREPROCESSOR_MODEL: Optional[str] = None
+
+    GPT_API_KEY: Optional[str] = None      # LLM_PROVIDER="openai" 일 때 필요
+    GOOGLE_API_KEY: Optional[str] = None   # LLM_PROVIDER="gemini" 일 때 필요
 
     # --- Database & Redis ---
     DB_USER: str

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1,7 +1,5 @@
 # app/services/agent.py
 from pydantic_ai import Agent
-from pydantic_ai.models.gemini import GeminiModel
-from pydantic_ai.providers.google_gla import GoogleGLAProvider
 from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelMessage
 import redis
 import json
@@ -9,32 +7,50 @@ from datetime import datetime, timezone
 from app.core.config import settings
 
 # ---------------------------------------------------------------------------
-# 모델 초기화
+# 모델 팩토리
 # ---------------------------------------------------------------------------
+# 모델/프로바이더를 바꾸려면 .env의 LLM_PROVIDER / ORCHESTRATOR_MODEL / PREPROCESSOR_MODEL만 수정하면 된다.
+# 코드 변경 불필요.
 
-# Flash — 비정형 데이터(Tavily, Instagram) 전처리·요약 전용
-flash_model = GeminiModel(
-    "gemini-2.0-flash",
-    provider=GoogleGLAProvider(api_key=settings.GOOGLE_API_KEY),
-)
+_PROVIDER_DEFAULTS = {
+    "openai":  {"orchestrator": "gpt-4o",        "preprocessor": "gpt-4o-mini"},
+    "gemini":  {"orchestrator": "gemini-2.5-pro", "preprocessor": "gemini-2.0-flash"},
+}
 
-# TODO: Pro — 오케스트레이터(의도 파악·도구 선택) 및 최종 응답 생성 전용
-#       현재 gemini-2.0-flash로 임시 대체. Pro 모델 확정 후 교체 필요.
-#       pro_model = GeminiModel(
-#           "gemini-2.5-pro",
-#           provider=GoogleGLAProvider(api_key=settings.GOOGLE_API_KEY),
-#       )
+def _build_model(role: str):
+    """role: 'orchestrator' | 'preprocessor'"""
+    provider = settings.LLM_PROVIDER
+    defaults = _PROVIDER_DEFAULTS.get(provider)
+    if defaults is None:
+        raise ValueError(f"지원하지 않는 LLM_PROVIDER: {provider!r}. 'openai' 또는 'gemini'를 사용하세요.")
+
+    if role == "orchestrator":
+        model_name = settings.ORCHESTRATOR_MODEL or defaults["orchestrator"]
+    elif role == "preprocessor":
+        model_name = settings.PREPROCESSOR_MODEL or defaults["preprocessor"]
+    else:
+        raise ValueError(f"알 수 없는 role: {role!r}")
+
+    if provider == "openai":
+        from pydantic_ai.models.openai import OpenAIModel
+        from pydantic_ai.providers.openai import OpenAIProvider
+        return OpenAIModel(model_name, provider=OpenAIProvider(api_key=settings.GPT_API_KEY))
+
+    # provider == "gemini"
+    from pydantic_ai.models.gemini import GeminiModel
+    from pydantic_ai.providers.google_gla import GoogleGLAProvider
+    return GeminiModel(model_name, provider=GoogleGLAProvider(api_key=settings.GOOGLE_API_KEY))
 
 # ---------------------------------------------------------------------------
 # 에이전트
 # ---------------------------------------------------------------------------
 
-# Flash 에이전트 — 비정형 전처리용
-flash_agent = Agent(model=flash_model)
+# 전처리 에이전트 — 비정형 데이터(Tavily, Instagram) 전처리·요약 전용
+preprocessor_agent = Agent(model=_build_model("preprocessor"))
 
-# TODO: Pro 에이전트 — 오케스트레이터 및 최종 응답 생성용
-#       pro_model 확정 후 아래 주석 해제
-#       pro_agent = Agent(model=pro_model)
+# TODO: 오케스트레이터 에이전트 — 의도 파악·도구 선택·최종 응답 생성
+#       구현 준비가 되면 아래 주석 해제
+# orchestrator_agent = Agent(model=_build_model("orchestrator"))
 
 # ---------------------------------------------------------------------------
 # Redis 클라이언트

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -48,9 +48,8 @@ def _build_model(role: str):
 # 전처리 에이전트 — 비정형 데이터(Tavily, Instagram) 전처리·요약 전용
 preprocessor_agent = Agent(model=_build_model("preprocessor"))
 
-# TODO: 오케스트레이터 에이전트 — 의도 파악·도구 선택·최종 응답 생성
-#       구현 준비가 되면 아래 주석 해제
-# orchestrator_agent = Agent(model=_build_model("orchestrator"))
+# 오케스트레이터 에이전트 — 의도 파악·도구 선택·최종 응답 생성
+orchestrator_agent = Agent(model=_build_model("orchestrator"))
 
 # ---------------------------------------------------------------------------
 # Redis 클라이언트

--- a/tests/ai/test_gpt.py
+++ b/tests/ai/test_gpt.py
@@ -1,0 +1,21 @@
+# import pytest
+# from pydantic_ai import Agent
+# from app.services.agent import _build_model
+
+
+# @pytest.mark.asyncio
+# async def test_gpt_preprocessor():
+#     """gpt-4o-mini (preprocessor) 연결 테스트"""
+#     agent = Agent(model=_build_model("preprocessor"))
+#     result = await agent.run("안녕! 한 문장으로 짧게 대답해줘.")
+#     print(f"\n[Preprocessor({agent.model})] {result.data}")
+#     assert result.data is not None
+
+
+# @pytest.mark.asyncio
+# async def test_gpt_orchestrator():
+#     """gpt-4o (orchestrator) 연결 테스트"""
+#     agent = Agent(model=_build_model("orchestrator"))
+#     result = await agent.run("안녕! 한 문장으로 짧게 대답해줘.")
+#     print(f"\n[Orchestrator({agent.model})] {result.data}")
+#     assert result.data is not None


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
LLM API 모델 ChatGpt 추가(기존 Gemini에서 변경)

# 연관 이슈 및 Close 할 이슈 작성
LLM API 모델 ChatGpt 추가(기존 Gemini에서 변경)

close #7 

# Pull Request 체크리스트
- [x] 🔥app/core/config.py — LLM_PROVIDER, ORCHESTRATOR_MODEL, PREPROCESSOR_MODEL 추가 / GPT_API_KEY, GOOGLE_API_KEY → Optional로 변경
- [x] 🔥app/services/agent.py — Gemini 하드코딩 제거, _build_model() 팩토리 추가, flash_agent → preprocessor_agent 리네임 
- [x] 🔥tests/ai/test_gpt.py — GPT 연결 테스트 추가 (사용 후 주석처리됨)           
- [x] 🔥 .env에 LLM_PROVIDER 및 GPT_API_KEY 추가

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현